### PR TITLE
Remove clang import from binding generator

### DIFF
--- a/src/bindingGenerators/matlabBindingGenerator.py
+++ b/src/bindingGenerators/matlabBindingGenerator.py
@@ -11,10 +11,7 @@ import os
 import shutil
 from typing import List
 
-import clang.cindex as cidx
-
 from . import clangParser
-from pickle import FALSE
 
 
 matlabBindingGeneratorLogger = logging.getLogger(__name__)
@@ -46,7 +43,9 @@ class MatlabBindingGenerator(object):
         '''
         self.__helicsParser = clangParser.HelicsHeaderParser(headerFiles)
         self.__rootDir = os.path.abspath(rootDir)
-        
+
+    def getParser(self):
+        return self.__helicsParser
         
     def generateSource(self):
         """
@@ -3974,17 +3973,17 @@ class MatlabBindingGenerator(object):
         helicsMexMainFunctionElements = []
         helicsMapTuples = []
         for cu in self.__helicsParser.parsedInfo.keys():
-            if self.__helicsParser.parsedInfo[cu]["kind"] == cidx.CursorKind.ENUM_DECL.name:
+            if self.__helicsParser.parsedInfo[cu]["kind"] == "ENUM_DECL":
                 createEnum(self.__helicsParser.parsedInfo[cu])
-            if self.__helicsParser.parsedInfo[cu]["kind"] == cidx.CursorKind.MACRO_DEFINITION.name:
+            if self.__helicsParser.parsedInfo[cu]["kind"] == "MACRO_DEFINITION":
                 macroMexWrapperFunctionStr, macroMexMainFunctionElementStr, macroMapTuple= createMacro(self.__helicsParser.parsedInfo[cu],int(cu))
                 helicsMexWrapperFunctions.append(macroMexWrapperFunctionStr)
                 helicsMexMainFunctionElements.append(macroMexMainFunctionElementStr)
                 if macroMapTuple != None:
                     helicsMapTuples.append(macroMapTuple)
-            if self.__helicsParser.parsedInfo[cu]["kind"] == cidx.CursorKind.VAR_DECL.name:
+            if self.__helicsParser.parsedInfo[cu]["kind"] == "VAR_DECL":
                 createVar(self.__helicsParser.parsedInfo[cu],int(cu))
-            if self.__helicsParser.parsedInfo[cu]["kind"] == cidx.CursorKind.FUNCTION_DECL.name:
+            if self.__helicsParser.parsedInfo[cu]["kind"] == "FUNCTION_DECL":
                 functionMexWrapperFunctionStr, functionMexMainFunctionElementStr, functionMapTuple= createFunction(self.__helicsParser.parsedInfo[cu],int(cu))
                 helicsMexWrapperFunctions.append(functionMexWrapperFunctionStr)
                 helicsMexMainFunctionElements.append(functionMexMainFunctionElementStr)


### PR DESCRIPTION
The name property just returns the variable name as a string, so the binding generator can be decoupled a bit more from the clang parsing code. There was also a stray import of `FALSE` from the `pickle` library.