### PR TITLE
Update macOS CI runner to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019,macos-11,ubuntu-20.04]
+        os: [windows-2019,macos-13,ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
The macos-11 runner is gone.