### PR TITLE
Use 2021a for Windows/Linux and 2022b for macOS-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019,macos-13,ubuntu-20.04]
+        os: [windows-2019,macos-12,ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Install latest HELICS release
         uses: gmlc-tdc/helics-action/install@main
-      - name: Set up MATLAB
+      - name: Set up MATLAB (macOS)
+        if: runner.os == 'macOS'
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
-          release: R2023b
+          release: R2022b
+      - name: Set up MATLAB
+        if: runner.os != 'macOS'
+        uses: matlab-actions/setup-matlab@v2.2.0
+        with:
+          release: R2021a
       - name: Set up MEX
         uses: matlab-actions/run-command@v2
         with:


### PR DESCRIPTION
Adjusting the CI build some to try to keep older MATLAB version support for Windows/Linux, and only use a newer version for the macOS build.