### PR TITLE
Update release artifact build systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
-          release: R2023b
+          release: R2022b
       - name: Set up MEX
         uses: matlab-actions/run-command@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
         if: runner.os == 'macOS'
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
-          release: R2022b
+          release: R2023b
       - name: Set up MATLAB
         if: runner.os != 'macOS'
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
-          release: R2021a
+          release: R2022b
       - name: Set up MEX
         uses: matlab-actions/run-command@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: gmlc-tdc/helics-action/install@main
       - name: Set up MATLAB (macOS)
         if: runner.os == 'macOS'
-        uses: matlab-actions/setup-matlab@v2.2.0
+        uses: matlab-actions/setup-matlab@v2.3.0
         with:
           release: R2023b
       - name: Set up MATLAB (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,16 @@ jobs:
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
           release: R2023b
-      - name: Set up MATLAB
-        if: runner.os != 'macOS'
+      - name: Set up MATLAB (Windows)
+        if: runner.os == 'Windows'
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
           release: R2022b
+      - name: Set up MATLAB (Linux)
+        if: runner.os == 'Linux'
+        uses: matlab-actions/setup-matlab@v2.2.0
+        with:
+          release: R2023a
       - name: Set up MEX
         uses: matlab-actions/run-command@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022,macos-13,ubuntu-22.04]
+        os: [windows-2022,macos-13,ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
@@ -35,7 +35,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: matlab-actions/setup-matlab@v2.2.0
         with:
-          release: R2023a
+          release: R2023b
       - name: Set up MEX
         uses: matlab-actions/run-command@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019,macos-12,ubuntu-20.04]
+        os: [windows-2022,macos-13,ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
Updates release asset build systems to Windows Server (MSVC) 2022, Ubuntu 22.04, and macOS 13 (due to upcoming deprecation of macOS 12 image in December).

Resolves #21