### PR TITLE
Update Ubuntu and macOS runner images for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022,macos-13,ubuntu-20.04]
+        os: [windows-2022,macos-14,ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
@@ -37,7 +37,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: matlab-actions/setup-matlab@v2.5.0
         with:
-          release: R2022b
+          release: R2024b
       - name: Set up MEX
         uses: matlab-actions/run-command@v2
         with:


### PR DESCRIPTION
Bump the macOS runner from 13 to 14, and the Ubuntu runner from 20.04 to 22.04; these are the oldest still available images.